### PR TITLE
Use a dedicated user `app` with permissions in `/app`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM node:23-slim
 
+# add a non-privileged user for running the application
+RUN groupadd --gid 10001 app && \
+    useradd -g app --uid 10001 --shell /usr/sbin/nologin --create-home --home-dir /app app
+
 WORKDIR /app
 
 COPY package.json ./
@@ -8,6 +12,8 @@ RUN npm install --no-package-lock; \
 
 # copy sources
 COPY update_remote_settings_records.mjs ./
+
+USER app
 
 # set CMD
 CMD ["node", "update_remote_settings_records.mjs"]


### PR DESCRIPTION
`/app` is the working dir. 

The script code uses relative location here:

https://github.com/mozilla/remote-settings-ondemand-crashes/blob/e489a96d7cb0f9aaa35a27dde8b4b4a5e0d5faff/update_remote_settings_records.mjs#L124


and here:

https://github.com/mozilla/remote-settings-ondemand-crashes/blob/e489a96d7cb0f9aaa35a27dde8b4b4a5e0d5faff/update_remote_settings_records.mjs#L149